### PR TITLE
feat: add check functionality to spec generator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,3 +28,11 @@ jobs:
           channel: nightly
           components: rustfmt
       - run: make format
+
+  spech-check:
+    name: OpenAPI Spec Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: moonrepo/setup-rust@v1
+      - run: make spec-check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -585,6 +585,7 @@ dependencies = [
  "clap",
  "color-eyre",
  "cs2kz-api",
+ "similar",
 ]
 
 [[package]]
@@ -2031,6 +2032,12 @@ name = "simdutf8"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
+
+[[package]]
+name = "similar"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2aeaf503862c419d66959f5d7ca015337d864e9c49485d771b732e2a20453597"
 
 [[package]]
 name = "simple_asn1"

--- a/Makefile
+++ b/Makefile
@@ -37,3 +37,9 @@ format:
 
 lint:
 	cargo clippy --all-features --workspace -- -D warnings
+
+spec:
+	cargo run -p cs2kz-api-spec-generator -- json
+
+spec-check:
+	cargo run -p cs2kz-api-spec-generator -- check

--- a/api-spec.json
+++ b/api-spec.json
@@ -1699,18 +1699,6 @@
           {
             "type": "string",
             "enum": [
-              "MissingApiKey"
-            ]
-          },
-          {
-            "type": "string",
-            "enum": [
-              "InvalidApiKey"
-            ]
-          },
-          {
-            "type": "string",
-            "enum": [
               "Unauthorized"
             ]
           },

--- a/cs2kz-api-spec-generator/Cargo.toml
+++ b/cs2kz-api-spec-generator/Cargo.toml
@@ -7,3 +7,6 @@ edition = "2021"
 color-eyre = { workspace = true }
 clap = { workspace = true }
 cs2kz-api = { path = "../cs2kz-api" }
+
+[dependencies.similar]
+version = "2.3.0"

--- a/cs2kz-api-spec-generator/src/main.rs
+++ b/cs2kz-api-spec-generator/src/main.rs
@@ -2,6 +2,7 @@ use {
 	clap::{Parser, Subcommand},
 	color_eyre::{eyre::Context, Result},
 	cs2kz_api::API,
+	similar::TextDiff,
 	std::path::PathBuf,
 };
 
@@ -13,8 +14,22 @@ struct Args {
 
 #[derive(Subcommand)]
 enum Output {
+	/// Do not write the output anywhere, just check against the existing output.
+	Check {
+		/// The path to the existing spec file.
+		#[clap(default_value = "./api-spec.json")]
+		path: PathBuf,
+	},
+
+	/// Write the generated spec to STDOUT.
 	Stdout,
-	Json { path: PathBuf },
+
+	/// Write the generated spec to a JSON file.
+	Json {
+		/// The path to the target spec file.
+		#[clap(default_value = "./api-spec.json")]
+		path: PathBuf,
+	},
 }
 
 fn main() -> Result<()> {
@@ -24,6 +39,20 @@ fn main() -> Result<()> {
 	let json = API::json()?;
 
 	match args.output {
+		Output::Check { path } => {
+			let check = std::fs::read_to_string(path).context("Failed to read spec file.")?;
+			let diff = TextDiff::from_lines(&check, &json);
+			let mut error = false;
+
+			for hunk in diff.unified_diff().iter_hunks() {
+				error = true;
+				eprintln!("{hunk}");
+			}
+
+			if error {
+				std::process::exit(1);
+			}
+		}
 		Output::Stdout => println!("{json}"),
 		Output::Json { path } => {
 			std::fs::write(path, json.into_bytes()).context("Failed to write JSON to disk.")?;


### PR DESCRIPTION
This adds a new subcommand to `cs2kz-api-spec-generator` which will
generate a diff with an existing spec file such that we can run it in
CI.
